### PR TITLE
Ensured that resource file types are loaded dynamically

### DIFF
--- a/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/DocumentGenerator.kt
+++ b/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/DocumentGenerator.kt
@@ -80,7 +80,8 @@ open class DocGenTask : DefaultTask() {
         @OutputDirectory
         get() = project.vdmGenDocsDir
 
-    private val resourceTypes = project.vdmConfig.resourceFileTypes
+    private val resourceTypes
+            get() = project.vdmConfig.resourceFileTypes
 
     val resourceFiles: FileCollection
         @InputFiles


### PR DESCRIPTION
The order of the consuming build gradle file can mean that VDM configuration is stale. This fix ensures that a stale copy of the configuration is not stored when the docGen task is created. 