### PR TITLE
Generated launch files for failing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ end TestExpectedFailures
 
 Test coverage can also be enabled (see [Configuration](#configuration)). When enabled HTML files are created in `${project.buildDir}/vdm/coverage`. There is one HTML file generated for each source file. Each file contains the text of the module with green and red highlighting indicating the locations that were hit or missed by the tests respectively. Tooltips indicate the number of times a specific location was hit. A rudimentary summary of statistics is also generated in `${project.buildDir}/vdm/coverage/report.html`.
 
+If tests fail, then launch files are generated that enable the test to be easily run from within Overtuere. These launch files can be found in `${project.buildDir}/vdm/testLaunch`. It is possible to configure this generation to produce launches for all tests or none at all. 
+
 ### check
 This task has no actions of its own, but ensures that all verification tasks have been executed.
 
@@ -316,7 +318,8 @@ The following attributes can be configured:
 |prettyPrinter.minListLengthToUseNls|5|The min list length at which to print list items on new lines when pretty printing|
 |resourceFileTypes|["svg", "png", "gif"]|The resource file types to include in generated documentation and associated packages|
 |autoDocGeneration|true|If true, automatically generates documentation before packaging|
-|recordCoverage|false|If true, generates HTML files illustrating test coverage of the specification|  
+|recordCoverage|false|If true, generates HTML files illustrating test coverage of the specification|
+|testLaunchGeneration|"FAILING"|Determines for which tests an Overture launch file will be generated. One of "ALL", "FAILING" or "NONE".  
 
 ## Examples
 Example projects and appropriate documentation can be found [here](examples).

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ end TestExpectedFailures
 
 Test coverage can also be enabled (see [Configuration](#configuration)). When enabled HTML files are created in `${project.buildDir}/vdm/coverage`. There is one HTML file generated for each source file. Each file contains the text of the module with green and red highlighting indicating the locations that were hit or missed by the tests respectively. Tooltips indicate the number of times a specific location was hit. A rudimentary summary of statistics is also generated in `${project.buildDir}/vdm/coverage/report.html`.
 
-If tests fail, then launch files are generated that enable the test to be easily run from within Overtuere. These launch files can be found in `${project.buildDir}/vdm/testLaunch`. It is possible to configure this generation to produce launches for all tests or none at all. 
+If tests fail, then launch files are generated that enable the test to be easily run from within Overture. These launch files can be found in `${project.buildDir}/vdm/testLaunch`. It is possible to configure this generation to produce launches for all tests or none at all. 
 
 ### check
 This task has no actions of its own, but ensures that all verification tasks have been executed.

--- a/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/EclipseLaunchDsl.kt
+++ b/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/EclipseLaunchDsl.kt
@@ -1,0 +1,71 @@
+/*
+ * #%~
+ * VDM Gradle Plugin
+ * %%
+ * Copyright (C) 2018 Anaplan Inc
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #~%
+ */
+package com.anaplan.engineering.vdmgradleplugin
+
+@DslMarker
+annotation class EclipseLaunchResultMarker
+
+@EclipseLaunchResultMarker
+abstract class EclipseLaunchXmlTag(tagName: String) : XmlTag(tagName)
+
+class LaunchConfigurationTag: EclipseLaunchXmlTag("launchConfiguration") {
+    @Attribute
+    val type = "org.overture.ide.vdmsl.debug.launchConfigurationType"
+
+    @ElementList
+    val typedAttributes = ArrayList<TypedAttributeTag>()
+
+    fun stringAttribute(init: StringAttributeTag.() -> Unit) {
+        val attributeTag = StringAttributeTag()
+        attributeTag.init()
+        typedAttributes.add(attributeTag)
+    }
+
+    fun booleanAttribute(init: BooleanAttributeTag.() -> Unit) {
+        val attributeTag = BooleanAttributeTag()
+        attributeTag.init()
+        typedAttributes.add(attributeTag)
+    }
+}
+
+abstract class TypedAttributeTag(tagName: String): EclipseLaunchXmlTag(tagName) {
+    @Attribute
+    var key: String? = null
+
+}
+
+class StringAttributeTag : TypedAttributeTag("stringAttribute") {
+    @Attribute
+    var value: String? = null
+}
+
+class BooleanAttributeTag : TypedAttributeTag("booleanAttribute") {
+    @Attribute
+    var value: Boolean? = null
+}
+
+fun testLaunch(init: LaunchConfigurationTag.() -> Unit): String {
+    val launchConfigurationTag = LaunchConfigurationTag()
+    launchConfigurationTag.init()
+    return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n$launchConfigurationTag"
+}
+

--- a/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/VdmConfig.kt
+++ b/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/VdmConfig.kt
@@ -36,6 +36,7 @@ open class VdmConfigExtension @javax.inject.Inject constructor(objectFactory: Ob
     var resourceFileTypes: Array<String> = arrayOf("svg", "png", "gif")
     var autoDocGeneration: Boolean = true
     var recordCoverage: Boolean = false
+    var testLaunchGeneration: TestLaunchGeneration = TestLaunchGeneration.FAILING
 
     fun packaging(action: Action<Packaging>) {
         action.execute(packaging)
@@ -48,6 +49,12 @@ open class VdmConfigExtension @javax.inject.Inject constructor(objectFactory: Ob
     fun prettyPrinter(action: Action<PrettyPrinterConfig>) {
         action.execute(prettyPrinter)
     }
+}
+
+enum class TestLaunchGeneration {
+    ALL,
+    NONE,
+    FAILING
 }
 
 open class Packaging @javax.inject.Inject constructor(@Suppress("UNUSED_PARAMETER") objectFactory: ObjectFactory) {

--- a/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/XmlDsl.kt
+++ b/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/XmlDsl.kt
@@ -1,0 +1,90 @@
+/*
+ * #%~
+ * VDM Gradle Plugin
+ * %%
+ * Copyright (C) 2018 Anaplan Inc
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #~%
+ */
+package com.anaplan.engineering.vdmgradleplugin
+
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.memberProperties
+
+interface ElementTag {
+    fun render(builder: StringBuilder, indent: String)
+}
+
+@Target(AnnotationTarget.PROPERTY)
+annotation class Attribute(
+        val name: String = ""
+)
+
+@Target(AnnotationTarget.PROPERTY)
+annotation class Element
+
+@Target(AnnotationTarget.PROPERTY)
+annotation class ElementList
+
+abstract class XmlTag(private val tagName: String) : ElementTag {
+
+    override fun render(builder: StringBuilder, indent: String) {
+        val elements = javaClass.kotlin.memberProperties.filter { property ->
+            property.findAnnotation<Element>() != null
+        }
+        val elementLists = javaClass.kotlin.memberProperties.filter { property ->
+            property.findAnnotation<ElementList>() != null
+        }
+        @Suppress("UNCHECKED_CAST") val childTags = elementLists.map { property -> property.get(this) as List<ElementTag> }.flatten() +
+                elements.map { property -> property.get(this) }.filterNotNull().map { it as ElementTag }
+        if (childTags.isEmpty()) {
+            builder.append("$indent<$tagName${renderAttributes()}/>\n")
+        } else {
+            builder.append("$indent<$tagName${renderAttributes()}>\n")
+            childTags.forEach { child ->
+                child.render(builder, "$indent  ")
+            }
+            builder.append("$indent</$tagName>\n")
+        }
+    }
+
+    private fun renderAttributes(): String {
+        val attributeProperties = javaClass.kotlin.memberProperties.filter { property ->
+            property.findAnnotation<Attribute>() != null
+        }
+        val builder = StringBuilder()
+        attributeProperties.forEach { property ->
+            val annotation = property.findAnnotation<Attribute>() as Attribute
+            val attributeName = if (annotation.name.isEmpty()) {
+                property.name
+            } else {
+                annotation.name
+            }
+            val value = property.get(this)
+            // ignore null attributes
+            if (value != null) {
+                builder.append(" $attributeName=\"$value\"")
+            }
+        }
+        return builder.toString()
+    }
+
+    override fun toString(): String {
+        val builder = StringBuilder()
+        render(builder, "")
+        return builder.toString()
+    }
+}

--- a/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/LaunchGenTest.kt
+++ b/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/LaunchGenTest.kt
@@ -1,0 +1,54 @@
+package com.anaplan.engineering.vdmgradleplugin
+
+import org.junit.Assert
+import org.junit.Test
+import java.io.File
+
+class LaunchGenTest {
+
+    private val testLaunchDir = "build/vdm/testLaunch/"
+
+    @Test
+    fun generateForAll() {
+        val dir = File(javaClass.getResource("/generateLaunchGenForAllTest").toURI())
+        executeBuild(
+                projectDir = dir,
+                tasks = arrayOf("test"),
+                fail = true)
+        val failedTestLaunchFile = File(dir, "$testLaunchDir/TestTest`TestAdd1.launch")
+        val passedTestLaunchFile = File(dir, "$testLaunchDir/TestTest`TestAdd2.launch")
+        Assert.assertTrue(failedTestLaunchFile.exists())
+        Assert.assertTrue(passedTestLaunchFile.exists())
+        Assert.assertEquals(File(javaClass.getResource("/generateLaunchGenForAllTest/TestTest`TestAdd1.launch").toURI()).readText(), failedTestLaunchFile.readText())
+        Assert.assertEquals(File(javaClass.getResource("/generateLaunchGenForAllTest/TestTest`TestAdd2.launch").toURI()).readText(), passedTestLaunchFile.readText())
+    }
+
+    @Test
+    fun generateForFailed() {
+        val dir = File(javaClass.getResource("/generateLaunchGenForFailedTest").toURI())
+        executeBuild(
+                projectDir = dir,
+                tasks = arrayOf("test"),
+                fail = true)
+        val failedTestLaunchFile = File(dir, "$testLaunchDir/TestTest`TestAdd1.launch")
+        val passedTestLaunchFile = File(dir, "$testLaunchDir/TestTest`TestAdd2.launch")
+        Assert.assertTrue(failedTestLaunchFile.exists())
+        Assert.assertFalse(passedTestLaunchFile.exists())
+        Assert.assertEquals(File(javaClass.getResource("/generateLaunchGenForFailedTest/TestTest`TestAdd1.launch").toURI()).readText(), failedTestLaunchFile.readText())
+    }
+
+    @Test
+    fun generateForNone() {
+        val dir = File(javaClass.getResource("/generateLaunchGenForNoneTest").toURI())
+        executeBuild(
+                projectDir = dir,
+                tasks = arrayOf("test"),
+                fail = true)
+        val failedTestLaunchFile = File(dir, "$testLaunchDir/TestTest`TestAdd1.launch")
+        val passedTestLaunchFile = File(dir, "$testLaunchDir/TestTest`TestAdd2.launch")
+        Assert.assertFalse(failedTestLaunchFile.exists())
+        Assert.assertFalse(passedTestLaunchFile.exists())
+    }
+
+
+}

--- a/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/UpToDateTest.kt
+++ b/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/UpToDateTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 import java.io.File
 import java.nio.file.Files
 
-class UpToDateTest {
+class generateLaunchGenForAllTestUpToDateTest {
 
     val mavenRepo = Files.createTempDirectory("maven")
 

--- a/src/test-fn/resources/generateLaunchGenForAllTest/TestTest`TestAdd1.launch
+++ b/src/test-fn/resources/generateLaunchGenForAllTest/TestTest`TestAdd1.launch
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launchConfiguration type="org.overture.ide.vdmsl.debug.launchConfigurationType">
+  <stringAttribute value="TestTest" key="vdm_launch_config_default"/>
+  <booleanAttribute value="true" key="vdm_launch_config_dtc_checks"/>
+  <stringAttribute value="TestTest`TestAdd1()" key="vdm_launch_config_expression"/>
+  <stringAttribute value="generateLaunchGenForAllTest" key="vdm_launch_config_project"/>
+  <stringAttribute value="TestAdd1()" key="vdm_launch_config_method"/>
+  <stringAttribute value="TestTest" key="vdm_launch_config_module"/>
+  <booleanAttribute value="true" key="vdm_launch_config_inv_checks"/>
+  <booleanAttribute value="true" key="vdm_launch_config_pre_checks"/>
+  <booleanAttribute value="true" key="vdm_launch_config_post_checks"/>
+  <booleanAttribute value="true" key="vdm_launch_config_measure_checks"/>
+</launchConfiguration>

--- a/src/test-fn/resources/generateLaunchGenForAllTest/TestTest`TestAdd2.launch
+++ b/src/test-fn/resources/generateLaunchGenForAllTest/TestTest`TestAdd2.launch
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launchConfiguration type="org.overture.ide.vdmsl.debug.launchConfigurationType">
+  <stringAttribute value="TestTest" key="vdm_launch_config_default"/>
+  <booleanAttribute value="true" key="vdm_launch_config_dtc_checks"/>
+  <stringAttribute value="TestTest`TestAdd2()" key="vdm_launch_config_expression"/>
+  <stringAttribute value="generateLaunchGenForAllTest" key="vdm_launch_config_project"/>
+  <stringAttribute value="TestAdd2()" key="vdm_launch_config_method"/>
+  <stringAttribute value="TestTest" key="vdm_launch_config_module"/>
+  <booleanAttribute value="true" key="vdm_launch_config_inv_checks"/>
+  <booleanAttribute value="true" key="vdm_launch_config_pre_checks"/>
+  <booleanAttribute value="true" key="vdm_launch_config_post_checks"/>
+  <booleanAttribute value="true" key="vdm_launch_config_measure_checks"/>
+</launchConfiguration>

--- a/src/test-fn/resources/generateLaunchGenForAllTest/build.gradle
+++ b/src/test-fn/resources/generateLaunchGenForAllTest/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id("vdm")
+}
+
+apply plugin: 'vdm'
+
+vdm {
+    testLaunchGeneration = 'ALL'
+}

--- a/src/test-fn/resources/generateLaunchGenForAllTest/src/main/vdm/parse-and-type-check-ok.vdmsl
+++ b/src/test-fn/resources/generateLaunchGenForAllTest/src/main/vdm/parse-and-type-check-ok.vdmsl
@@ -1,0 +1,9 @@
+module Main
+
+definitions
+
+values
+
+x : nat = 1
+
+end Main

--- a/src/test-fn/resources/generateLaunchGenForAllTest/src/test/vdm/testTest.vdmsl
+++ b/src/test-fn/resources/generateLaunchGenForAllTest/src/test/vdm/testTest.vdmsl
@@ -1,0 +1,22 @@
+module TestTest
+
+definitions
+
+functions
+
+  Add:nat * nat -> nat
+  Add(a,b) == a + b
+
+operations
+
+  TestAdd1:() ==> nat
+  TestAdd1() == Add(1,1)
+  post RESULT = 3;
+
+  TestAdd2:() ==> nat
+  TestAdd2() == Add(1,1)
+  post RESULT = 2;
+
+end TestTest
+
+

--- a/src/test-fn/resources/generateLaunchGenForFailedTest/TestTest`TestAdd1.launch
+++ b/src/test-fn/resources/generateLaunchGenForFailedTest/TestTest`TestAdd1.launch
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launchConfiguration type="org.overture.ide.vdmsl.debug.launchConfigurationType">
+  <stringAttribute value="TestTest" key="vdm_launch_config_default"/>
+  <booleanAttribute value="true" key="vdm_launch_config_dtc_checks"/>
+  <stringAttribute value="TestTest`TestAdd1()" key="vdm_launch_config_expression"/>
+  <stringAttribute value="generateLaunchGenForFailedTest" key="vdm_launch_config_project"/>
+  <stringAttribute value="TestAdd1()" key="vdm_launch_config_method"/>
+  <stringAttribute value="TestTest" key="vdm_launch_config_module"/>
+  <booleanAttribute value="true" key="vdm_launch_config_inv_checks"/>
+  <booleanAttribute value="true" key="vdm_launch_config_pre_checks"/>
+  <booleanAttribute value="true" key="vdm_launch_config_post_checks"/>
+  <booleanAttribute value="true" key="vdm_launch_config_measure_checks"/>
+</launchConfiguration>

--- a/src/test-fn/resources/generateLaunchGenForFailedTest/build.gradle
+++ b/src/test-fn/resources/generateLaunchGenForFailedTest/build.gradle
@@ -1,0 +1,5 @@
+plugins {
+    id("vdm")
+}
+
+apply plugin: 'vdm'

--- a/src/test-fn/resources/generateLaunchGenForFailedTest/src/main/vdm/parse-and-type-check-ok.vdmsl
+++ b/src/test-fn/resources/generateLaunchGenForFailedTest/src/main/vdm/parse-and-type-check-ok.vdmsl
@@ -1,0 +1,9 @@
+module Main
+
+definitions
+
+values
+
+x : nat = 1
+
+end Main

--- a/src/test-fn/resources/generateLaunchGenForFailedTest/src/test/vdm/testTest.vdmsl
+++ b/src/test-fn/resources/generateLaunchGenForFailedTest/src/test/vdm/testTest.vdmsl
@@ -1,0 +1,22 @@
+module TestTest
+
+definitions
+
+functions
+
+  Add:nat * nat -> nat
+  Add(a,b) == a + b
+
+operations
+
+  TestAdd1:() ==> nat
+  TestAdd1() == Add(1,1)
+  post RESULT = 3;
+
+  TestAdd2:() ==> nat
+  TestAdd2() == Add(1,1)
+  post RESULT = 2;
+
+end TestTest
+
+

--- a/src/test-fn/resources/generateLaunchGenForNoneTest/build.gradle
+++ b/src/test-fn/resources/generateLaunchGenForNoneTest/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id("vdm")
+}
+
+apply plugin: 'vdm'
+
+vdm {
+    testLaunchGeneration = 'NONE'
+}

--- a/src/test-fn/resources/generateLaunchGenForNoneTest/src/main/vdm/parse-and-type-check-ok.vdmsl
+++ b/src/test-fn/resources/generateLaunchGenForNoneTest/src/main/vdm/parse-and-type-check-ok.vdmsl
@@ -1,0 +1,9 @@
+module Main
+
+definitions
+
+values
+
+x : nat = 1
+
+end Main

--- a/src/test-fn/resources/generateLaunchGenForNoneTest/src/test/vdm/testTest.vdmsl
+++ b/src/test-fn/resources/generateLaunchGenForNoneTest/src/test/vdm/testTest.vdmsl
@@ -1,0 +1,22 @@
+module TestTest
+
+definitions
+
+functions
+
+  Add:nat * nat -> nat
+  Add(a,b) == a + b
+
+operations
+
+  TestAdd1:() ==> nat
+  TestAdd1() == Add(1,1)
+  post RESULT = 3;
+
+  TestAdd2:() ==> nat
+  TestAdd2() == Add(1,1)
+  post RESULT = 2;
+
+end TestTest
+
+

--- a/src/test/kotlin/com/anaplan/engineering/vdmgradleplugin/EclipseLaunchDslTest.kt
+++ b/src/test/kotlin/com/anaplan/engineering/vdmgradleplugin/EclipseLaunchDslTest.kt
@@ -1,0 +1,59 @@
+package com.anaplan.engineering.vdmgradleplugin
+
+import org.junit.Assert
+import org.junit.Test
+import java.nio.file.Paths
+
+class EclipseLaunchDslTest {
+
+    @Test
+    fun standardLaunch() = check("standard-launch") {
+        testLaunch {
+            stringAttribute {
+                key = "vdm_launch_config_default"
+                value = "MyModule"
+            }
+            booleanAttribute {
+                key = "vdm_launch_config_dtc_checks"
+                value = true
+            }
+            stringAttribute {
+                key = "vdm_launch_config_expression"
+                value = "MyModule`MyTest()"
+            }
+            stringAttribute {
+                key = "vdm_launch_config_project"
+                value = "my-project"
+            }
+            stringAttribute {
+                key = "vdm_launch_config_method"
+                value = "MyTest()"
+            }
+            stringAttribute {
+                key = "vdm_launch_config_module"
+                value = "MyModule"
+            }
+            booleanAttribute {
+                key = "vdm_launch_config_inv_checks"
+                value = true
+            }
+            booleanAttribute {
+                key = "vdm_launch_config_pre_checks"
+                value = true
+            }
+            booleanAttribute {
+                key = "vdm_launch_config_post_checks"
+                value = true
+            }
+            booleanAttribute {
+                key = "vdm_launch_config_measure_checks"
+                value = true
+            }
+        }
+    }
+
+    private fun check(testName: String, generator: () -> String) {
+        val expectedFile = Paths.get(javaClass.getResource("$testName.launch").toURI())
+        Assert.assertEquals(expectedFile.toFile().readText(), generator())
+    }
+}

--- a/src/test/resources/com/anaplan/engineering/vdmgradleplugin/standard-launch.launch
+++ b/src/test/resources/com/anaplan/engineering/vdmgradleplugin/standard-launch.launch
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launchConfiguration type="org.overture.ide.vdmsl.debug.launchConfigurationType">
+  <stringAttribute value="MyModule" key="vdm_launch_config_default"/>
+  <booleanAttribute value="true" key="vdm_launch_config_dtc_checks"/>
+  <stringAttribute value="MyModule`MyTest()" key="vdm_launch_config_expression"/>
+  <stringAttribute value="my-project" key="vdm_launch_config_project"/>
+  <stringAttribute value="MyTest()" key="vdm_launch_config_method"/>
+  <stringAttribute value="MyModule" key="vdm_launch_config_module"/>
+  <booleanAttribute value="true" key="vdm_launch_config_inv_checks"/>
+  <booleanAttribute value="true" key="vdm_launch_config_pre_checks"/>
+  <booleanAttribute value="true" key="vdm_launch_config_post_checks"/>
+  <booleanAttribute value="true" key="vdm_launch_config_measure_checks"/>
+</launchConfiguration>


### PR DESCRIPTION
When tests fail it can be time consuming to configure Overture to run
and debug those tests. This change causes a `launch` file to be
generated in `${project.buildDir}/vdm/testLaunch`. This enables the test
to be run using a single click in Overture. By default the launch files
are generated for failing tests, but this can be configured, so that
launch files are generated for all tests or none.