### PR TITLE
Used javaexec to execute tests in forked jvm

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     implementation group: 'com.atlassian.commonmark', name: 'commonmark', version: '0.11.0'
     implementation group: 'com.atlassian.commonmark', name: 'commonmark-ext-gfm-tables', version: '0.9.0'
 
+    implementation group: 'com.xenomachina', name: 'kotlin-argparser', version: '2.0.7'
+
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation group: 'com.nhaarman', name: 'mockito-kotlin', version: '1.5.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,19 @@ sourceSets {
     functionalTest {
         kotlin.srcDir 'src/test-fn/kotlin'
         resources.srcDir 'src/test-fn/resources'
-        compileClasspath += sourceSets.main.output + configurations.testRuntime
-        runtimeClasspath += output + compileClasspath
+    }
+}
+
+task functionalTestClasspathJar(type: Jar) {
+    inputs.files(sourceSets.test.runtimeClasspath)
+            .withPropertyName("runtimeClasspath")
+            .withNormalizer(ClasspathNormalizer)
+    archiveName = "functionalTestClasspath.jar"
+    doFirst {
+        manifest {
+            def classpath = sourceSets.test.runtimeClasspath.files
+            attributes "Class-Path": classpath.collect { f -> f.toURI().toString() }.join(" ")
+        }
     }
 }
 
@@ -56,8 +67,10 @@ task functionalTest(type: Test) {
     group = LifecycleBasePlugin.VERIFICATION_GROUP
     testClassesDirs = sourceSets.functionalTest.output.classesDirs
     classpath = sourceSets.functionalTest.runtimeClasspath
+    systemProperty "functionalTestClasspathJar", functionalTestClasspathJar.archivePath.absolutePath
     outputs.upToDateWhen { false }
     mustRunAfter test
+    dependsOn functionalTestClasspathJar
 }
 
 check.dependsOn functionalTest

--- a/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/CoverageRecorder.kt
+++ b/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/CoverageRecorder.kt
@@ -25,11 +25,10 @@ import kotlinx.html.*
 import kotlinx.html.stream.appendHTML
 import org.overture.ast.lex.LexLocation
 import org.overture.interpreter.runtime.ModuleInterpreter
-import org.slf4j.Logger
 import java.io.File
 
 internal class CoverageRecorder(
-        private val sourceDir: File,
+        private val sourceDir: File?,
         private val coverageDir: File,
         private val logger: Logger
 ) {
@@ -122,7 +121,7 @@ internal class CoverageRecorder(
     }
 
     private fun generateCoverage(interpreter: ModuleInterpreter) =
-            interpreter.modules.filter { it.files.all { it.startsWith(sourceDir) } }.flatMap { module ->
+            interpreter.modules.filter { sourceDir == null || it.files.all { it.startsWith(sourceDir) } }.flatMap { module ->
                 module.files.map { file ->
                     val locationCoverage = LexLocation.getSourceLocations(file).map { location ->
                         Location(

--- a/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/ForkedTestRunner.kt
+++ b/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/ForkedTestRunner.kt
@@ -1,0 +1,393 @@
+package com.anaplan.engineering.vdmgradleplugin
+
+import com.xenomachina.argparser.ArgParser
+import com.xenomachina.argparser.SystemExitException
+import com.xenomachina.argparser.default
+import org.overture.ast.definitions.SOperationDefinition
+import org.overture.interpreter.runtime.ContextException
+import org.overture.interpreter.runtime.Interpreter
+import org.overture.interpreter.runtime.ModuleInterpreter
+import java.io.File
+import java.io.PrintStream
+import java.net.InetAddress
+import java.nio.file.Files
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.system.exitProcess
+
+internal val timestampFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+
+fun main(args: Array<String>) {
+    try {
+        ForkedTestRunner(ArgParser(args)).runTests()
+    } catch (e: SystemExitException) {
+        e.printAndExit()
+    }
+    exitProcess(0)
+}
+
+/**
+ * There are some issues with logging in a way that is consistent with the build. If we use a logger here, we have
+ * difficulty maintaining consistency with parent process. For this reason we use the gradle log level but simply output
+ * to stdout/stderr according to that level.
+ */
+internal class Logger(private val logLevel: GradleLogLevel) {
+
+    fun error(msg: String) = log(msg, GradleLogLevel.ERROR, System.err)
+    fun info(msg: String) = log(msg, GradleLogLevel.INFO, System.out)
+    fun debug(msg: String) = log(msg, GradleLogLevel.DEBUG, System.out)
+
+    private fun log(msg: String, at: GradleLogLevel, printStream: PrintStream) {
+        if (at.level >= logLevel.level) {
+            printStream.println(msg)
+        }
+    }
+
+}
+
+internal enum class GradleLogLevel(val level: Int) {
+    DEBUG(1),
+    INFO(2),
+    LIFECYCLE(3),
+    WARN(4),
+    QUIET(5),
+    ERROR(6)
+}
+
+/**
+ * This class is used to run VDM tests in a separate JVM and is invoked using main method above.
+ */
+// TODO - generic test runner could be extracted to a separate project
+class ForkedTestRunner(parser: ArgParser) {
+
+    private val logLevel by parser.storing("The logging level") {
+        GradleLogLevel.valueOf(this)
+    }.default(GradleLogLevel.ERROR)
+
+    private val dialect by parser.storing("The VDM dialect") {
+        Dialect.valueOf(this)
+    }.default(Dialect.vdmsl)
+
+    private val coverageTargetDir by parser.storing("Directory to write coverage results") {
+        File(this)
+    }.default { null }
+
+    private val reportTargetDir by parser.storing("Directory to write test reports") {
+        File(this)
+    }
+
+    private val launchTargetDir by parser.storing("Directory to write generated test launch files") {
+        File(this)
+    }.default { null }
+
+    private val testLaunchGeneration by parser.storing("Generate test launch files for all, failing or no tests") {
+        TestLaunchGeneration.valueOf(this)
+    }.default { TestLaunchGeneration.FAILING }
+
+    private val testLaunchProjectName by parser.storing("Project name required for test launch").default { null }
+
+    private val coverageSourceDir by parser.storing("Limit coverage to files in the specified folder") {
+        File(this)
+    }.default { null }
+
+    private val testSourceDir by parser.storing("Limit tests to those found in files in the specified folder") {
+        File(this)
+    }.default { null }
+
+    private val specificationFiles by parser.positionalList("Specification files") {
+        File(this)
+    }
+
+    private val logger = Logger(logLevel)
+
+    fun runTests() {
+        if (dialect != Dialect.vdmsl) {
+            logger.error("Test running only defined for VDM-SL currently")
+            exitProcess(1)
+        }
+        val interpreter = loadSpecification()
+        val testSuites = collectTests(interpreter)
+        val testResults = TestRunner(interpreter, logger).run(testSuites)
+        saveFormattedResults(testResults)
+        logTestResults(testResults)
+        if (coverageTargetDir != null) {
+            // TODO -- coverage need to be able to distinguish between code under tests and dependencies
+            CoverageRecorder(coverageSourceDir, coverageTargetDir!!, logger).recordCoverage(interpreter)
+        }
+        generateLaunchFiles(testResults)
+
+        if (!testResults.all { it.succeeded }) {
+            logger.error("There were failing tests")
+            exitProcess(1)
+        }
+    }
+
+    private fun generateLaunchFiles(testResults: List<TestSuiteResult>) {
+        if (launchTargetDir == null) {
+            if (testLaunchGeneration != TestLaunchGeneration.NONE) {
+                logger.error("Asked to generate launch files, but no launch target directory specified")
+                exitProcess(1)
+            }
+            return
+        }
+        if (launchTargetDir!!.exists()) {
+            deleteDirectory(launchTargetDir!!)
+        }
+        launchTargetDir!!.mkdirs()
+        if (testLaunchGeneration == TestLaunchGeneration.NONE) {
+            return
+        }
+        if (testLaunchProjectName == null) {
+            logger.error("Asked to generate launch files, but no test launch project name specified")
+            exitProcess(1)
+        }
+        testResults.forEach { suite ->
+            suite.testResults.filter { test ->
+                testLaunchGeneration == TestLaunchGeneration.ALL || test.state != TestResultState.PASS
+            }.forEach { test ->
+                val xml = testLaunch {
+                    stringAttribute {
+                        key = "vdm_launch_config_default"
+                        value = suite.moduleName
+                    }
+                    booleanAttribute {
+                        key = "vdm_launch_config_dtc_checks"
+                        value = true
+                    }
+                    stringAttribute {
+                        key = "vdm_launch_config_expression"
+                        value = "${suite.moduleName}`${test.testName}()"
+                    }
+                    stringAttribute {
+                        key = "vdm_launch_config_project"
+                        value = testLaunchProjectName
+                    }
+                    stringAttribute {
+                        key = "vdm_launch_config_method"
+                        value = "${test.testName}()"
+                    }
+                    stringAttribute {
+                        key = "vdm_launch_config_module"
+                        value = suite.moduleName
+                    }
+                    booleanAttribute {
+                        key = "vdm_launch_config_inv_checks"
+                        value = true
+                    }
+                    booleanAttribute {
+                        key = "vdm_launch_config_pre_checks"
+                        value = true
+                    }
+                    booleanAttribute {
+                        key = "vdm_launch_config_post_checks"
+                        value = true
+                    }
+                    booleanAttribute {
+                        key = "vdm_launch_config_measure_checks"
+                        value = true
+                    }
+                }
+                File(launchTargetDir, "${suite.moduleName}`${test.testName}.launch").writeText(xml)
+            }
+        }
+    }
+
+    private fun logTestResults(testResults: List<TestSuiteResult>) {
+        if (testResults.all { it.succeeded }) {
+            logger.info("SUCCESS -- ${testResults.sumBy { it.testCount }} tests passed")
+        } else {
+            logger.info("FAILURE -- ${testResults.sumBy { it.failCount }} tests failed, ${testResults.sumBy { it.errorCount }} tests had errors [${testResults.sumBy { it.testCount }} tests were run]")
+        }
+    }
+
+    private fun loadSpecification(): ModuleInterpreter {
+        // For coverage we need to reparse to correctly identify lex locations in files
+        val controller = dialect.createController()
+        controller.parse(specificationFiles)
+        controller.typeCheck()
+        return controller.getInterpreter() as? ModuleInterpreter
+        // this should never happen as we have limited dialect to VDM-SL
+                ?: exitProcess(2)
+    }
+
+    private fun collectTests(interpreter: ModuleInterpreter): List<TestSuite> {
+        val testModules = interpreter.modules.filter { module ->
+            module.files.all { testSourceDir == null || it.startsWith(testSourceDir!!) } &&
+                    module.name.name.startsWith("Test")
+        }
+        return testModules.map { module ->
+            val operationDefs = module.defs.filter { it is SOperationDefinition }.map { it as SOperationDefinition }
+            // TODO - should check that operation has zero params
+            val testNames = operationDefs.filter { it.name.name.startsWith("Test") }.map { it.name.name }
+            TestSuite(module.name.name, testNames)
+        }
+    }
+
+    private fun saveFormattedResults(testSuiteResults: List<TestSuiteResult>) {
+        if (reportTargetDir.exists()) {
+            deleteDirectory(reportTargetDir)
+        }
+        reportTargetDir.mkdirs()
+        testSuiteResults.forEach { saveFormattedResults(it, reportTargetDir) }
+    }
+
+    private fun saveFormattedResults(testSuiteResult: TestSuiteResult, reportDir: File) {
+        val reportFile = File(reportDir, "TEST-${testSuiteResult.moduleName}.xml")
+        val xml = testSuite {
+            setTime(testSuiteResult.duration)
+            name = testSuiteResult.moduleName
+            tests = testSuiteResult.testCount
+            failures = testSuiteResult.failCount
+            errors = testSuiteResult.errorCount
+            timestamp = timestampFormatter.format(testSuiteResult.timestamp)
+            hostname = InetAddress.getLocalHost().hostName
+            testSuiteResult.testResults.forEach { testResult ->
+                testCase {
+                    setTime(testResult.duration)
+                    name = testResult.testName
+                    classname = testSuiteResult.moduleName
+                    if (testResult.state == TestResultState.FAIL) {
+                        failure {
+                            message = testResult.message
+                        }
+                    }
+                    if (testResult.state == TestResultState.ERROR) {
+                        error {
+                            message = testResult.message
+                        }
+                    }
+                }
+            }
+        }
+        Files.write(reportFile.toPath(), xml.toByteArray())
+    }
+
+
+}
+
+private data class TestSuite(
+        val moduleName: String,
+        val testNames: List<String>
+)
+
+private enum class TestResultState {
+    PASS,
+    FAIL,
+    ERROR
+}
+
+private data class TestResult(
+        val testName: String,
+        val duration: Long,
+        val state: TestResultState,
+        val message: String? = null
+)
+
+private data class TestSuiteResult(
+        val moduleName: String,
+        val timestamp: LocalDateTime,
+        val testResults: List<TestResult>
+) {
+    val errorCount: Int by lazy {
+        testResults.count { it.state == TestResultState.ERROR }
+    }
+    val failCount: Int by lazy {
+        testResults.count { it.state == TestResultState.FAIL }
+    }
+    val testCount: Int by lazy {
+        testResults.size
+    }
+    val duration: Long by lazy {
+        testResults.sumByLong { it.duration }
+    }
+    val succeeded: Boolean by lazy {
+        testResults.all { it.state == TestResultState.PASS }
+    }
+}
+
+// copies _Collections.sumBy for long
+private inline fun <T> Iterable<T>.sumByLong(selector: (T) -> Long): Long {
+    var sum: Long = 0
+    for (element in this) {
+        sum += selector(element)
+    }
+    return sum
+}
+
+private enum class ExpectedTestResult(val description: String) {
+    success("success"),
+    failedPrecondition("precondition failure"),
+    failedPostcondition("postcondition failure"),
+    failedInvariant("invariant failure")
+}
+
+// ideally this would be done through an annotation, but this is not feasible currently
+private fun getExpectedResult(testName: String): ExpectedTestResult {
+    val testNameLower = testName.toLowerCase()
+    return if (testNameLower.toLowerCase().contains("expectpreconditionfailure")) {
+        ExpectedTestResult.failedPrecondition
+    } else if (testNameLower.contains("expectpostconditionfailure")) {
+        ExpectedTestResult.failedPostcondition
+    } else if (testNameLower.contains("expectinvariantfailure")) {
+        ExpectedTestResult.failedInvariant
+    } else {
+        ExpectedTestResult.success
+    }
+}
+
+private val preconditionFailureCodes = setOf(4055, 4071)
+private val postconditionFailureCodes = setOf(4056, 4072)
+private val invariantFailureCodes = setOf(4060, 4079, 4082)
+
+private class TestRunner(private val interpreter: Interpreter, private val logger: Logger) {
+
+    internal fun run(testSuites: List<TestSuite>): List<TestSuiteResult> {
+        interpreter.init(null)
+        val timestamp = LocalDateTime.now()
+        return testSuites.map { run(it, timestamp) }
+    }
+
+    private fun run(testSuite: TestSuite, timestamp: LocalDateTime): TestSuiteResult {
+        interpreter.defaultName = testSuite.moduleName
+        val testResults = testSuite.testNames.map { run(testSuite.moduleName, it) }
+        return TestSuiteResult(testSuite.moduleName, timestamp, testResults)
+    }
+
+    private fun run(moduleName: String, testName: String): TestResult {
+        val expectedResult = getExpectedResult(testName)
+        val start = System.currentTimeMillis()
+        return try {
+            interpreter.execute("$testName()", null)
+            val duration = System.currentTimeMillis() - start
+            if (expectedResult == ExpectedTestResult.success) {
+                logger.debug("PASS .. $moduleName`$testName")
+                TestResult(testName, duration, TestResultState.PASS)
+            } else {
+                val msg = "test passed, but expected ${expectedResult.description}"
+                logger.info("FAIL .. $moduleName`$testName -- $msg")
+                TestResult(testName, duration, TestResultState.FAIL, msg)
+            }
+        } catch (e: ContextException) {
+            val duration = System.currentTimeMillis() - start
+            // Post condition failure is considered a test failure, any other unexpected exception (pre/inv) is an error
+            if (postconditionFailureCodes.contains(e.number)) {
+                if (expectedResult == ExpectedTestResult.failedPostcondition) {
+                    logger.debug("PASS .. $moduleName`$testName")
+                    TestResult(testName, duration, TestResultState.PASS)
+                } else {
+                    logger.info("FAIL .. $moduleName`$testName")
+                    TestResult(testName, duration, TestResultState.FAIL, e.message)
+                }
+            } else if (preconditionFailureCodes.contains(e.number) && expectedResult == ExpectedTestResult.failedPrecondition) {
+                logger.debug("PASS .. $moduleName`$testName")
+                TestResult(testName, duration, TestResultState.PASS)
+            } else if (invariantFailureCodes.contains(e.number) && expectedResult == ExpectedTestResult.failedInvariant) {
+                logger.debug("PASS .. $moduleName`$testName")
+                TestResult(testName, duration, TestResultState.PASS)
+            } else {
+                logger.info("ERRR .. $moduleName`$testName")
+                TestResult(testName, duration, TestResultState.ERROR, e.message)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/TestRunner.kt
+++ b/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/TestRunner.kt
@@ -91,6 +91,7 @@ open class VdmTestRunTask() : JavaExec() {
     }
 
     private fun createClassPathJar(): File {
+        println(project.buildscript.configurations.getByName("classpath").files())
         val classpath = project.buildscript.configurations.getByName("classpath").plus(
                 project.configurations.getByName(vdmConfigurationName)
         ).filter { it.extension == "jar" }

--- a/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/TestRunner.kt
+++ b/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/TestRunner.kt
@@ -21,25 +21,11 @@
  */
 package com.anaplan.engineering.vdmgradleplugin
 
-import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.logging.Logger
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.TaskAction
-import org.gradle.internal.classloader.VisitableURLClassLoader
+import org.gradle.api.tasks.*
 import org.gradle.language.base.plugins.LifecycleBasePlugin
-import org.overture.ast.definitions.SOperationDefinition
-import org.overture.interpreter.runtime.ContextException
-import org.overture.interpreter.runtime.Interpreter
-import org.overture.interpreter.runtime.ModuleInterpreter
-import org.overture.interpreter.util.Delegate
 import java.io.File
-import java.net.InetAddress
-import java.nio.file.Files
-import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 internal const val test = "test"
@@ -55,9 +41,7 @@ internal fun Project.addTestTask() {
     }
 }
 
-internal val timestampFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-
-open class VdmTestRunTask() : DefaultTask() {
+open class VdmTestRunTask() : JavaExec() {
 
     val dialect: Dialect
         @Input
@@ -87,296 +71,31 @@ open class VdmTestRunTask() : DefaultTask() {
         @OutputDirectory
         get() = File(project.vdmBuildDir, "testLaunch")
 
-    @TaskAction
-    fun runTests() {
+    private fun constructArgs() =
+            if (recordCoverage) {
+                listOf("--coverage-target-dir", coverageDir.absolutePath)
+            } else {
+                emptyList()
+            } +
+                    listOf(
+                            "--log-level", project.gradle.startParameter.logLevel,
+                            "--report-target-dir", reportDir.absolutePath,
+                            "--launch-target-dir", launchDir.absolutePath,
+                            "--test-launch-generation", testLaunchGeneration.name,
+                            "--test-launch-project-name", project.name,
+                            "--coverage-source-dir", project.vdmSourceDir.absolutePath,
+                            "--test-source-dir", project.vdmTestSourceDir.absolutePath
+                    ) + project.locateAllSpecifications(dialect, true).map { it.absolutePath }
+
+    override fun exec() {
         if (dialect != Dialect.vdmsl) {
             throw GradleException("Test running only defined for VDM-SL currently")
         }
-        makeVdmLibsAvailableForDelegation()
-        val interpreter = loadSpecification()
-        val testSuites = collectTests(interpreter)
-        val testRunner = TestRunner(interpreter, logger)
-        val testResults = testRunner.run(testSuites)
-        saveFormattedResults(testResults)
-        logTestResults(testResults)
-        if (recordCoverage) {
-            CoverageRecorder(project.vdmSourceDir, coverageDir, logger).recordCoverage(interpreter)
-        }
-        generateLaunchFiles(testResults)
-        if (!testResults.all { it.succeeded }) {
-            throw GradleException("There were test failures")
-        }
-    }
-
-    private fun makeVdmLibsAvailableForDelegation() {
-        // Requires a dependence on Gradle internal, but alternative is completely separate JVM which is far
-        // more work
-        locateFilesWithExtension(project.vdmLibDir, "jar").map { it.toURI().toURL() }.forEach { url ->
-            (Delegate::class.java.classLoader as VisitableURLClassLoader).addURL(url)
-        }
-    }
-
-    private fun generateLaunchFiles(testResults: List<TestSuiteResult>) {
-        if (launchDir.exists()) {
-            deleteDirectory(launchDir)
-        }
-        launchDir.mkdirs()
-        if (testLaunchGeneration == TestLaunchGeneration.NONE) {
-            return
-        }
-        testResults.forEach { suite ->
-            suite.testResults.filter { test ->
-                testLaunchGeneration == TestLaunchGeneration.ALL || test.state != TestResultState.PASS
-            }.forEach { test ->
-                val xml = testLaunch {
-                    stringAttribute {
-                        key = "vdm_launch_config_default"
-                        value = suite.moduleName
-                    }
-                    booleanAttribute {
-                        key = "vdm_launch_config_dtc_checks"
-                        value = true
-                    }
-                    stringAttribute {
-                        key = "vdm_launch_config_expression"
-                        value = "${suite.moduleName}`${test.testName}()"
-                    }
-                    stringAttribute {
-                        key = "vdm_launch_config_project"
-                        value = project.name
-                    }
-                    stringAttribute {
-                        key = "vdm_launch_config_method"
-                        value = "${test.testName}()"
-                    }
-                    stringAttribute {
-                        key = "vdm_launch_config_module"
-                        value = suite.moduleName
-                    }
-                    booleanAttribute {
-                        key = "vdm_launch_config_inv_checks"
-                        value = true
-                    }
-                    booleanAttribute {
-                        key = "vdm_launch_config_pre_checks"
-                        value = true
-                    }
-                    booleanAttribute {
-                        key = "vdm_launch_config_post_checks"
-                        value = true
-                    }
-                    booleanAttribute {
-                        key = "vdm_launch_config_measure_checks"
-                        value = true
-                    }
-                }
-                File(launchDir, "${suite.moduleName}`${test.testName}.launch").writeText(xml)
-            }
-        }
-    }
-
-    private fun logTestResults(testResults: List<TestSuiteResult>) {
-        if (logger.isInfoEnabled) {
-            if (testResults.all { it.succeeded }) {
-                logger.info("SUCCESS -- ${testResults.sumBy { it.testCount }} tests passed")
-            } else {
-                logger.info("FAILURE -- ${testResults.sumBy { it.failCount }} tests failed, ${testResults.sumBy { it.errorCount }} tests had errors [${testResults.sumBy { it.testCount }} tests were run]")
-            }
-        }
-    }
-
-    private fun loadSpecification() =
-            if (recordCoverage) {
-                // For coverage we need to reparse to correctly identify lex locations in files
-                val controller = dialect.createController()
-                controller.parse(project.locateAllSpecifications(dialect, true).toList())
-                controller.typeCheck()
-                controller.getInterpreter()
-            } else {
-                project.loadBinarySpecification(generatedLibFile)
-            } as? ModuleInterpreter
-                    ?: // this should never happen as we have limited dialect to VDM-SL
-                    throw GradleException("Interpreter is not a container interpreter!")
-
-
-    private fun collectTests(interpreter: ModuleInterpreter): List<TestSuite> {
-        val testModules = interpreter.modules.filter { module ->
-            module.files.all { it.startsWith(project.vdmTestSourceDir) } &&
-                    module.name.name.startsWith("Test")
-        }
-        return testModules.map { module ->
-            val operationDefs = module.defs.filter { it is SOperationDefinition }.map { it as SOperationDefinition }
-            // TODO - should check that operation has zero params
-            val testNames = operationDefs.filter { it.name.name.startsWith("Test") }.map { it.name.name }
-            TestSuite(module.name.name, testNames)
-        }
-    }
-
-    private fun saveFormattedResults(testSuiteResults: List<TestSuiteResult>) {
-        if (reportDir.exists()) {
-            deleteDirectory(reportDir)
-        }
-        reportDir.mkdirs()
-        testSuiteResults.forEach { saveFormattedResults(it, reportDir) }
-    }
-
-    private fun saveFormattedResults(testSuiteResult: TestSuiteResult, reportDir: File) {
-        val reportFile = File(reportDir, "TEST-${testSuiteResult.moduleName}.xml")
-        val xml = testSuite {
-            setTime(testSuiteResult.duration)
-            name = testSuiteResult.moduleName
-            tests = testSuiteResult.testCount
-            failures = testSuiteResult.failCount
-            errors = testSuiteResult.errorCount
-            timestamp = timestampFormatter.format(testSuiteResult.timestamp)
-            hostname = InetAddress.getLocalHost().hostName
-            testSuiteResult.testResults.forEach { testResult ->
-                testCase {
-                    setTime(testResult.duration)
-                    name = testResult.testName
-                    classname = testSuiteResult.moduleName
-                    if (testResult.state == TestResultState.FAIL) {
-                        failure {
-                            message = testResult.message
-                        }
-                    }
-                    if (testResult.state == TestResultState.ERROR) {
-                        error {
-                            message = testResult.message
-                        }
-                    }
-                }
-            }
-        }
-        Files.write(reportFile.toPath(), xml.toByteArray())
-    }
-
-
-}
-
-private data class TestSuite(
-        val moduleName: String,
-        val testNames: List<String>
-)
-
-private enum class TestResultState {
-    PASS,
-    FAIL,
-    ERROR
-}
-
-private data class TestResult(
-        val testName: String,
-        val duration: Long,
-        val state: TestResultState,
-        val message: String? = null
-)
-
-private data class TestSuiteResult(
-        val moduleName: String,
-        val timestamp: LocalDateTime,
-        val testResults: List<TestResult>
-) {
-    val errorCount: Int by lazy {
-        testResults.count { it.state == TestResultState.ERROR }
-    }
-    val failCount: Int by lazy {
-        testResults.count { it.state == TestResultState.FAIL }
-    }
-    val testCount: Int by lazy {
-        testResults.size
-    }
-    val duration: Long by lazy {
-        testResults.sumByLong { it.duration }
-    }
-    val succeeded: Boolean by lazy {
-        testResults.all { it.state == TestResultState.PASS }
-    }
-}
-
-// copies _Collections.sumBy for long
-private inline fun <T> Iterable<T>.sumByLong(selector: (T) -> Long): Long {
-    var sum: Long = 0
-    for (element in this) {
-        sum += selector(element)
-    }
-    return sum
-}
-
-private enum class ExpectedTestResult(val description: String) {
-    success("success"),
-    failedPrecondition("precondition failure"),
-    failedPostcondition("postcondition failure"),
-    failedInvariant("invariant failure")
-}
-
-// ideally this would be done through an annotation, but this is not feasible currently
-private fun getExpectedResult(testName: String): ExpectedTestResult {
-    val testNameLower = testName.toLowerCase()
-    return if (testNameLower.toLowerCase().contains("expectpreconditionfailure")) {
-        ExpectedTestResult.failedPrecondition
-    } else if (testNameLower.contains("expectpostconditionfailure")) {
-        ExpectedTestResult.failedPostcondition
-    } else if (testNameLower.contains("expectinvariantfailure")) {
-        ExpectedTestResult.failedInvariant
-    } else {
-        ExpectedTestResult.success
-    }
-}
-
-private val preconditionFailureCodes = setOf(4055, 4071)
-private val postconditionFailureCodes = setOf(4056, 4072)
-private val invariantFailureCodes = setOf(4060, 4079, 4082)
-
-private class TestRunner(private val interpreter: Interpreter, private val logger: Logger) {
-
-    internal fun run(testSuites: List<TestSuite>): List<TestSuiteResult> {
-        interpreter.init(null)
-        val timestamp = LocalDateTime.now()
-        return testSuites.map { run(it, timestamp) }
-    }
-
-    private fun run(testSuite: TestSuite, timestamp: LocalDateTime): TestSuiteResult {
-        interpreter.defaultName = testSuite.moduleName
-        val testResults = testSuite.testNames.map { run(testSuite.moduleName, it) }
-        return TestSuiteResult(testSuite.moduleName, timestamp, testResults)
-    }
-
-    private fun run(moduleName: String, testName: String): TestResult {
-        val expectedResult = getExpectedResult(testName)
-        val start = System.currentTimeMillis()
-        return try {
-            interpreter.execute("$testName()", null)
-            val duration = System.currentTimeMillis() - start
-            if (expectedResult == ExpectedTestResult.success) {
-                logger.debug("PASS .. $moduleName`$testName")
-                TestResult(testName, duration, TestResultState.PASS)
-            } else {
-                val msg = "test passed, but expected ${expectedResult.description}"
-                logger.info("FAIL .. $moduleName`$testName -- $msg")
-                TestResult(testName, duration, TestResultState.FAIL, msg)
-            }
-        } catch (e: ContextException) {
-            val duration = System.currentTimeMillis() - start
-            // Post condition failure is considered a test failure, any other unexpected exception (pre/inv) is an error
-            if (postconditionFailureCodes.contains(e.number)) {
-                if (expectedResult == ExpectedTestResult.failedPostcondition) {
-                    logger.debug("PASS .. $moduleName`$testName")
-                    TestResult(testName, duration, TestResultState.PASS)
-                } else {
-                    logger.info("FAIL .. $moduleName`$testName")
-                    TestResult(testName, duration, TestResultState.FAIL, e.message)
-                }
-            } else if (preconditionFailureCodes.contains(e.number) && expectedResult == ExpectedTestResult.failedPrecondition) {
-                logger.debug("PASS .. $moduleName`$testName")
-                TestResult(testName, duration, TestResultState.PASS)
-            } else if (invariantFailureCodes.contains(e.number) && expectedResult == ExpectedTestResult.failedInvariant) {
-                logger.debug("PASS .. $moduleName`$testName")
-                TestResult(testName, duration, TestResultState.PASS)
-            } else {
-                logger.info("ERRR .. $moduleName`$testName")
-                TestResult(testName, duration, TestResultState.ERROR, e.message)
-            }
-        }
+        super.setMain("com.anaplan.engineering.vdmgradleplugin.ForkedTestRunnerKt")
+        super.setArgs(constructArgs())
+        super.setClasspath(project.buildscript.configurations.getByName("classpath").plus(
+                project.configurations.getByName(vdmConfigurationName)
+        ))
+        super.exec()
     }
 }

--- a/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/VdmGradlePlugin.kt
+++ b/src/main/kotlin/com/anaplan/engineering/vdmgradleplugin/VdmGradlePlugin.kt
@@ -146,11 +146,12 @@ internal fun locateFilesWithExtension(directory: File, vararg extensions: String
     return files.map { it.toFile() }
 }
 
+internal val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
+
 internal fun deleteDirectory(directory: File) {
     if (!directory.exists()) {
         return
     }
-    val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val fileVisitor = object : SimpleFileVisitor<Path>() {
         override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
             delete(file)

--- a/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/CoverageTest.kt
+++ b/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/CoverageTest.kt
@@ -1,5 +1,6 @@
 package com.anaplan.engineering.vdmgradleplugin
 
+import com.anaplan.engineering.vdmgradleplugin.TestRunner.executeBuild
 import org.junit.Assert
 import org.junit.Test
 import java.io.File

--- a/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/DocGenTest.kt
+++ b/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/DocGenTest.kt
@@ -21,6 +21,7 @@
  */
 package com.anaplan.engineering.vdmgradleplugin
 
+import com.anaplan.engineering.vdmgradleplugin.TestRunner.executeBuild
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/LaunchGenTest.kt
+++ b/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/LaunchGenTest.kt
@@ -1,5 +1,6 @@
 package com.anaplan.engineering.vdmgradleplugin
 
+import com.anaplan.engineering.vdmgradleplugin.TestRunner.executeBuild
 import org.junit.Assert
 import org.junit.Test
 import java.io.File

--- a/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/LibCleanerTest.kt
+++ b/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/LibCleanerTest.kt
@@ -21,6 +21,7 @@
  */
 package com.anaplan.engineering.vdmgradleplugin
 
+import com.anaplan.engineering.vdmgradleplugin.TestRunner.executeBuild
 import org.junit.Assert
 import org.junit.Test
 import java.io.File

--- a/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/ManifestTest.kt
+++ b/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/ManifestTest.kt
@@ -1,5 +1,6 @@
 package com.anaplan.engineering.vdmgradleplugin
 
+import com.anaplan.engineering.vdmgradleplugin.TestRunner.executeBuild
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/PackageTest.kt
+++ b/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/PackageTest.kt
@@ -21,6 +21,7 @@
  */
 package com.anaplan.engineering.vdmgradleplugin
 
+import com.anaplan.engineering.vdmgradleplugin.TestRunner.executeBuild
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/PublishAndDependencyTest.kt
+++ b/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/PublishAndDependencyTest.kt
@@ -21,6 +21,7 @@
  */
 package com.anaplan.engineering.vdmgradleplugin
 
+import com.anaplan.engineering.vdmgradleplugin.TestRunner.executeBuild
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/TestTest.kt
+++ b/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/TestTest.kt
@@ -21,6 +21,7 @@
  */
 package com.anaplan.engineering.vdmgradleplugin
 
+import com.anaplan.engineering.vdmgradleplugin.TestRunner.executeBuild
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/TypeCheckTest.kt
+++ b/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/TypeCheckTest.kt
@@ -21,6 +21,7 @@
  */
 package com.anaplan.engineering.vdmgradleplugin
 
+import com.anaplan.engineering.vdmgradleplugin.TestRunner.executeBuild
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/UpToDateTest.kt
+++ b/src/test-fn/kotlin/com/anaplan/engineering/vdmgradleplugin/UpToDateTest.kt
@@ -1,5 +1,6 @@
 package com.anaplan.engineering.vdmgradleplugin
 
+import com.anaplan.engineering.vdmgradleplugin.TestRunner.executeBuild
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
 import org.junit.Test
@@ -1223,8 +1224,10 @@ class generateLaunchGenForAllTestUpToDateTest {
     """.trimMargin()
 
     private val useVdmPlugin = """
-        |plugins {
-        |    id("vdm")
+        |buildscript {
+        |    dependencies {
+        |        classpath files("${TestRunner.functionalTestClasspathJar}")
+        |    }
         |}
         |
         |apply plugin: 'vdm'

--- a/src/test-fn/resources/coverageTest/build.gradle
+++ b/src/test-fn/resources/coverageTest/build.gradle
@@ -1,9 +1,12 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
+
+apply plugin: 'vdm'
 
 vdm {
     recordCoverage = true
 }
 
-apply plugin: 'vdm'

--- a/src/test-fn/resources/customSourceFolders/build.gradle
+++ b/src/test-fn/resources/customSourceFolders/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/diamondDependencyClash/a1/build.gradle
+++ b/src/test-fn/resources/diamondDependencyClash/a1/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/diamondDependencyClash/a2/build.gradle
+++ b/src/test-fn/resources/diamondDependencyClash/a2/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/diamondDependencyClash/b/build.gradle
+++ b/src/test-fn/resources/diamondDependencyClash/b/build.gradle
@@ -1,6 +1,9 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
+
 
 group = "testing"
 version = "1.0.0"

--- a/src/test-fn/resources/diamondDependencyClash/c/build.gradle
+++ b/src/test-fn/resources/diamondDependencyClash/c/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/diamondDependencyClash/d/build.gradle
+++ b/src/test-fn/resources/diamondDependencyClash/d/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/diamondDependencyClashWithExclusion/a1/build.gradle
+++ b/src/test-fn/resources/diamondDependencyClashWithExclusion/a1/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/diamondDependencyClashWithExclusion/a2/build.gradle
+++ b/src/test-fn/resources/diamondDependencyClashWithExclusion/a2/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/diamondDependencyClashWithExclusion/b/build.gradle
+++ b/src/test-fn/resources/diamondDependencyClashWithExclusion/b/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/diamondDependencyClashWithExclusion/c/build.gradle
+++ b/src/test-fn/resources/diamondDependencyClashWithExclusion/c/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/diamondDependencyClashWithExclusion/d/build.gradle
+++ b/src/test-fn/resources/diamondDependencyClashWithExclusion/d/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/diamondDependencyOk/a/build.gradle
+++ b/src/test-fn/resources/diamondDependencyOk/a/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/diamondDependencyOk/b/build.gradle
+++ b/src/test-fn/resources/diamondDependencyOk/b/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/diamondDependencyOk/c/build.gradle
+++ b/src/test-fn/resources/diamondDependencyOk/c/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/diamondDependencyOk/d/build.gradle
+++ b/src/test-fn/resources/diamondDependencyOk/d/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/erroredTest/build.gradle
+++ b/src/test-fn/resources/erroredTest/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/expectedInvAndDidntGetTest/build.gradle
+++ b/src/test-fn/resources/expectedInvAndDidntGetTest/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/expectedInvAndGotTest/build.gradle
+++ b/src/test-fn/resources/expectedInvAndGotTest/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/expectedPostAndDidntGetTest/build.gradle
+++ b/src/test-fn/resources/expectedPostAndDidntGetTest/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/expectedPostAndGotTest/build.gradle
+++ b/src/test-fn/resources/expectedPostAndGotTest/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/expectedPreAndDidntGetTest/build.gradle
+++ b/src/test-fn/resources/expectedPreAndDidntGetTest/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/expectedPreAndGotTest/build.gradle
+++ b/src/test-fn/resources/expectedPreAndGotTest/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/failingTest/build.gradle
+++ b/src/test-fn/resources/failingTest/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/generateAnchor/project/build.gradle
+++ b/src/test-fn/resources/generateAnchor/project/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/generateLaunchGenForAllTest/build.gradle
+++ b/src/test-fn/resources/generateLaunchGenForAllTest/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/generateLaunchGenForFailedTest/build.gradle
+++ b/src/test-fn/resources/generateLaunchGenForFailedTest/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/generateLaunchGenForNoneTest/build.gradle
+++ b/src/test-fn/resources/generateLaunchGenForNoneTest/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/generateLocalPageLink/project/build.gradle
+++ b/src/test-fn/resources/generateLocalPageLink/project/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/generateModuleLink/project/build.gradle
+++ b/src/test-fn/resources/generateModuleLink/project/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/generateModuleList/project/build.gradle
+++ b/src/test-fn/resources/generateModuleList/project/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/generateModuleRef/project/build.gradle
+++ b/src/test-fn/resources/generateModuleRef/project/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/generateMultipleModuleRef/project/build.gradle
+++ b/src/test-fn/resources/generateMultipleModuleRef/project/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/generateMultipleModuleRefEscaped/project/build.gradle
+++ b/src/test-fn/resources/generateMultipleModuleRefEscaped/project/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/generatePlainPage/project/build.gradle
+++ b/src/test-fn/resources/generatePlainPage/project/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/generateSubDir/project/build.gradle
+++ b/src/test-fn/resources/generateSubDir/project/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/generateTestModuleList/project/build.gradle
+++ b/src/test-fn/resources/generateTestModuleList/project/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/generateWithResources/project/build.gradle
+++ b/src/test-fn/resources/generateWithResources/project/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/libCleanerTest/vdmlib/build.gradle
+++ b/src/test-fn/resources/libCleanerTest/vdmlib/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/noAutoDocGen/a/build.gradle
+++ b/src/test-fn/resources/noAutoDocGen/a/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/noCoverageTest/build.gradle
+++ b/src/test-fn/resources/noCoverageTest/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/packageWithNesting/build.gradle
+++ b/src/test-fn/resources/packageWithNesting/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/packageWithResources/build.gradle
+++ b/src/test-fn/resources/packageWithResources/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/parseAndTypeCheckOk/build.gradle
+++ b/src/test-fn/resources/parseAndTypeCheckOk/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/parseAndTypeCheckTestsOk/build.gradle
+++ b/src/test-fn/resources/parseAndTypeCheckTestsOk/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/parseAndTypeCheckTestsWithMdOk/build.gradle
+++ b/src/test-fn/resources/parseAndTypeCheckTestsWithMdOk/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/parseError/build.gradle
+++ b/src/test-fn/resources/parseError/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/parseErrorInTests/build.gradle
+++ b/src/test-fn/resources/parseErrorInTests/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/passingTest/build.gradle
+++ b/src/test-fn/resources/passingTest/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/publishAndConsumeLib/vdmlib/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeLib/vdmlib/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishAndConsumeMain/a/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeMain/a/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishAndConsumeMain/b/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeMain/b/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishAndConsumeMd/a/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeMd/a/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishAndConsumeMd/b/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeMd/b/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishAndConsumeTest/a/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeTest/a/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishAndConsumeTest/b/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeTest/b/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishAndConsumeTransitiveLib/consumer/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeTransitiveLib/consumer/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishAndConsumeTransitiveLib/vdmlib/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeTransitiveLib/vdmlib/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishAndConsumeTransitiveMain/a/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeTransitiveMain/a/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishAndConsumeTransitiveMain/b/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeTransitiveMain/b/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishAndConsumeTransitiveMain/c/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeTransitiveMain/c/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishAndConsumeTransitiveMd/a/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeTransitiveMd/a/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishAndConsumeTransitiveMd/b/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeTransitiveMd/b/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishAndConsumeTransitiveMd/c/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeTransitiveMd/c/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishAndConsumeTransitiveTest/a/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeTransitiveTest/a/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishAndConsumeTransitiveTest/b/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeTransitiveTest/b/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishAndConsumeTransitiveTest/c/build.gradle
+++ b/src/test-fn/resources/publishAndConsumeTransitiveTest/c/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishButDontConsumeMd/a/build.gradle
+++ b/src/test-fn/resources/publishButDontConsumeMd/a/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishButDontConsumeMd/b/build.gradle
+++ b/src/test-fn/resources/publishButDontConsumeMd/b/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishButDontConsumeTest/a/build.gradle
+++ b/src/test-fn/resources/publishButDontConsumeTest/a/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishButDontConsumeTest/b/build.gradle
+++ b/src/test-fn/resources/publishButDontConsumeTest/b/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishMain/a/build.gradle
+++ b/src/test-fn/resources/publishMain/a/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishMainAndDocSource/a/build.gradle
+++ b/src/test-fn/resources/publishMainAndDocSource/a/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/publishMainAndTest/a/build.gradle
+++ b/src/test-fn/resources/publishMainAndTest/a/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/renderDefaultModule/project/build.gradle
+++ b/src/test-fn/resources/renderDefaultModule/project/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/renderModules/project/build.gradle
+++ b/src/test-fn/resources/renderModules/project/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/renderTestModules/project/build.gradle
+++ b/src/test-fn/resources/renderTestModules/project/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/splittingISO8601/char/build.gradle
+++ b/src/test-fn/resources/splittingISO8601/char/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/splittingISO8601/iso8601/build.gradle
+++ b/src/test-fn/resources/splittingISO8601/iso8601/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/splittingISO8601/numeric/build.gradle
+++ b/src/test-fn/resources/splittingISO8601/numeric/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/splittingISO8601/ord/build.gradle
+++ b/src/test-fn/resources/splittingISO8601/ord/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/splittingISO8601/seq/build.gradle
+++ b/src/test-fn/resources/splittingISO8601/seq/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-  id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/splittingISO8601/set/build.gradle
+++ b/src/test-fn/resources/splittingISO8601/set/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 group = "testing"

--- a/src/test-fn/resources/typeCheckError/build.gradle
+++ b/src/test-fn/resources/typeCheckError/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/typeCheckErrorInTests/build.gradle
+++ b/src/test-fn/resources/typeCheckErrorInTests/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/wrongDialect/build.gradle
+++ b/src/test-fn/resources/wrongDialect/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'

--- a/src/test-fn/resources/wrongFileExtensionIgnored/build.gradle
+++ b/src/test-fn/resources/wrongFileExtensionIgnored/build.gradle
@@ -1,5 +1,7 @@
-plugins {
-    id("vdm")
+buildscript {
+    dependencies {
+        classpath files("%functionalTestClasspath.jar%")
+    }
 }
 
 apply plugin: 'vdm'


### PR DESCRIPTION
When using Java libs there was an issue that the gradle daemon would
keep a JVM alive between test runs. This meant that additions to the
classloader from one run were being preserved for subsequent runs with
negative consequences.

Tests are now executed in a forked JVM using Gradle's javaexec task.
Longer term we could consider breaking the test runner into a separate
project, but inconsistencies in logging strategies might make this more
difficult than it first appears.